### PR TITLE
[fixed] changed instances of unique_ptr to shared_ptr that were being implicitly copied inside std::map<> since unique_ptr's cannot be copied

### DIFF
--- a/common/eq_physics.cpp
+++ b/common/eq_physics.cpp
@@ -15,9 +15,9 @@ struct btMeshInfo
 		rb.reset(rb_in);
 	}
 
-	std::unique_ptr<btTriangleMesh> mesh;
-	std::unique_ptr<btBvhTriangleMeshShape> mesh_shape;
-	std::unique_ptr<btRigidBody> rb;
+	std::shared_ptr<btTriangleMesh> mesh;
+	std::shared_ptr<btBvhTriangleMeshShape> mesh_shape;
+	std::shared_ptr<btRigidBody> rb;
 };
 
 struct EQPhysics::impl {


### PR DESCRIPTION
unique_ptr's can't be used inside STL containers because they are implicitly copied during normal operation. shared_ptr's can be copied, so the solution to this problem is to used shared_ptr inside STL containers. This problem throws a compile error in VS2013, and this fix corrects that.