### PR TITLE
Add arg support

### DIFF
--- a/src/map_edit/main.cpp
+++ b/src/map_edit/main.cpp
@@ -24,6 +24,15 @@ int main(int argc, char **argv)
 		return -1;
 	}
 
+
+	char* zone = nullptr;
+	for (int i = 0; i < argc; i++) {
+		if (i > 0) {
+			zone = argv[i];
+			eqLogMessage(LogInfo, "loading %s\n", zone);
+		}
+	}
+
 	glfwWindowHint(GLFW_SAMPLES, 4);
 	glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
 	glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
@@ -58,6 +67,9 @@ int main(int argc, char **argv)
 	scene->RegisterModule(new ModuleVolume());
 	scene->RegisterModule(new ModuleWP());
 	scene->Init(win);
+	if (zone != nullptr) {
+		scene->LoadScene(zone);
+	}
 
 	glfwSetFramebufferSizeCallback(win, [](GLFWwindow *win, int width, int height) {
 		scene->Resize(width, height);

--- a/src/map_edit/main.cpp
+++ b/src/map_edit/main.cpp
@@ -30,6 +30,7 @@ int main(int argc, char **argv)
 		if (i > 0) {
 			zone = argv[i];
 			eqLogMessage(LogInfo, "loading %s\n", zone);
+			break;
 		}
 	}
 


### PR DESCRIPTION
This PR adds arg support to map_edit, so you can run e.g. `map_edit.exe clz` to open map edit with clz already opened.

This is to assist my eqgzi-manager project